### PR TITLE
Update authorizations configuration

### DIFF
--- a/content/4.digging-deeper/4.authorizations.md
+++ b/content/4.digging-deeper/4.authorizations.md
@@ -8,9 +8,9 @@ Laravel Rest Api doesn't provide authentication, you can define it on your proje
 
 ## Policies
 
-To restrict access to viewing, creating, updating, or deleting resources, Laravel Rest Api relies on Laravel's authorization policies.
+To restrict access to viewing, creating, updating, or deleting resources, Laravel Rest Api relies on Laravel's [authorization policies](https://laravel.com/docs/authorization#creating-policies).
 By default, Laravel automatically associates the appropriate authorization policies with your models.
-You can also manually associate a policy in your AppServiceProvider. In either case, Laravel REST API will use it automatically, without requiring any additional configuration.
+You can also manually associate a policy in your `AppServiceProvider`. In either case, Laravel REST API will use it automatically, without requiring any additional configuration.
 
 This concerns the following methods:
 - viewAny

--- a/content/4.digging-deeper/4.authorizations.md
+++ b/content/4.digging-deeper/4.authorizations.md
@@ -8,8 +8,9 @@ Laravel Rest Api doesn't provide authentication, you can define it on your proje
 
 ## Policies
 
-To restrict access to viewing, creating, updating, or deleting resources, Laravel Rest Api leverages Laravel's [authorization policies](https://laravel.com/docs/authorization#creating-policies).
-Basically, if your model is associated with a policy in your `AppServiceProvider`, Laravel Rest API will automatically use it, requiring no further configuration.
+To restrict access to viewing, creating, updating, or deleting resources, Laravel Rest Api relies on Laravel's authorization policies.
+By default, Laravel automatically associates the appropriate authorization policies with your models.
+You can also manually associate a policy in your AppServiceProvider. In either case, Laravel REST API will use it automatically, without requiring any additional configuration.
 
 This concerns the following methods:
 - viewAny


### PR DESCRIPTION
Since Laravel 11, Gates are automatically imported. It is also possible to import them manually. This PR updates the explanation of how to use Laravel authorizations.