### PR TITLE
Default limit

### DIFF
--- a/content/3.resources/2.exposed-data.md
+++ b/content/3.resources/2.exposed-data.md
@@ -108,6 +108,11 @@ To add a limit to a resource, you may simply add it to the resource's `limits` m
     }
 ```
 
+If no limit is specified in the request, the Laravel REST API paginates with 50 items. You can also set a default limit by specifying it in your resource:
+```php
+    public int $defaultLimit = 20;
+```
+
 ### Conditional limits specifying
 
 You might want to choose the limits you are exposing depending on the user. You can achieve this by conditioning the `limits` method:

--- a/content/3.resources/2.exposed-data.md
+++ b/content/3.resources/2.exposed-data.md
@@ -108,7 +108,7 @@ To add a limit to a resource, you may simply add it to the resource's `limits` m
     }
 ```
 
-If no limit is specified in the request, the Laravel REST API paginates with 50 items. You can also set a default limit by specifying it in your resource:
+If no limit is specified in the request, Rest Api paginates with 50 items. You can also set a default limit by specifying it in your resource:
 ```php
     public int $defaultLimit = 20;
 ```


### PR DESCRIPTION
Updates documentation to reflect new functionality: Default limit in resource

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- API requests without a specified limit now return 50 items per page.
	- Enhanced configuration options provide a default resource limit of 20.
- **Documentation**
	- Updated guidance clarifies the API’s default pagination behavior and available configuration settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->