### PR TITLE
trashed text search

### DIFF
--- a/content/2.endpoints/2.search.md
+++ b/content/2.endpoints/2.search.md
@@ -562,24 +562,27 @@ If you want to specify a full text search you'll need to use the text argument. 
 
 When using full text search, some restrictions happens to the query:
 
-| **Key**             | **Changes**                                            |
-|---------------------|--------------------------------------------------------|
-| **Scopes**          |                                                        |
-| `scopes.name`       | Not allowed                                            | 
-| `scopes.parameters` | Not allowed                                            |          
-| **Filters**         |                                                        |         
-| `filters.field`     | take scout fields instead of fields in resource detail |                 
-| `filters.operator`  | `=`/`in`/`not in`                                      |                         
-| `filters.type`      | Not allowed                                            |
-| `filters.nested`    | Not allowed                                            | 
-| **Sorts**           |                                                        |         
-| `sorts.field`       | take scout fields instead of fields in resource detail |
+| **Key**             | **Changes**                                                     |
+|---------------------|-----------------------------------------------------------------|
+| **Scopes**          |                                                                 |
+| `scopes.name`       | Not allowed                                                     | 
+| `scopes.parameters` | Not allowed                                                     |          
+| **Filters**         |                                                                 |         
+| `filters.field`     | take scout fields instead of fields in resource detail          |                 
+| `filters.operator`  | `=`/`in`/`not in`                                               |                         
+| `filters.type`      | Not allowed                                                     |
+| `filters.nested`    | Not allowed                                                     | 
+| **Sorts**           |                                                                 |         
+| `sorts.field`       | uses Scout fields instead of fields defined in resource details | 
 
+#### Text search with trashed models
 
-#### Text search with trash
+Because the Laravel Scout Builder differs from Eloquent, `withTrashed` is not a scope when performing text search.  
+Instead, control trashed handling via the `text.trashed` option:
 
-Because the Laravel Scout Builder is not built the same as the Eloquent one, `withTrashed` instruction is not a scope
-anymore and work differently:
+- "with"  → include both non-trashed and trashed records
+- "only"  → include only trashed records
+- omitted → exclude trashed records (default)
 
 ```json
 // (POST) api/posts/search
@@ -588,20 +591,6 @@ anymore and work differently:
     "text": {
       "value": "my text search",
       "trashed": "with"
-    }
-  }
-}
-```
-
-or for `onlyTrashed`:
-
-```json
-// (POST) api/posts/search
-{
-  "search": {
-    "text": {
-      "value": "my text search",
-      "trashed": "only"
     }
   }
 }

--- a/content/2.endpoints/2.search.md
+++ b/content/2.endpoints/2.search.md
@@ -573,4 +573,36 @@ When using full text search, some restrictions happens to the query:
 | `filters.type`      | Not allowed                                            |
 | `filters.nested`    | Not allowed                                            | 
 | **Sorts**           |                                                        |         
-| `sorts.field`       | take scout fields instead of fields in resource detail |      
+| `sorts.field`       | take scout fields instead of fields in resource detail |
+
+
+#### Text search with trash
+
+Because the Laravel Scout Builder is not built the same as the Eloquent one, `withTrashed` instruction is not a scope
+anymore and work differently:
+
+```json
+// (POST) api/posts/search
+{
+  "search": {
+    "text": {
+      "value": "my text search",
+      "trashed": "with"
+    }
+  }
+}
+```
+
+or for `onlyTrashed`:
+
+```json
+// (POST) api/posts/search
+{
+  "search": {
+    "text": {
+      "value": "my text search",
+      "trashed": "only"
+    }
+  }
+}
+```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a “Text search with trash” subsection, including JSON examples for trashed handling (trashed: "with" and trashed: "only") and how to set trashed behavior in requests.
  - Clarified that Laravel Scout Builder differs from Eloquent and that withTrashed is not applicable to text search.
  - Minor formatting update to the Impacts table (no semantic change).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->