### PR TITLE
Gating with custom message

### DIFF
--- a/content/4.digging-deeper/3.gates.md
+++ b/content/4.digging-deeper/3.gates.md
@@ -39,12 +39,12 @@ class UserResource extends Resource
 }
 ```
 
-## Policy message in gates
+## Policy messages in gates
 
-You are able to get policies message if you want to be more explicit about why the policy is not passing, you first need to set the 
-config `rest.gates.message.enabled` to true. Be aware that this will change the gates format
+To surface policy messages explaining authorization failures, first set the config `rest.gates.message.enabled` to `true`.
+Enabling this changes the `gates` payload shape returned by the `search` endpoint and may require frontend updates.
 
-In your policy you need to return a policy message:
+In your policy, return an authorization `Response`:
 
 ```php
 use App\Models\Post;
@@ -62,14 +62,13 @@ public function update(User $user, Post $post): Response
 }
 ```
 
-and this will result in the change of the `search` gating format:
+This changes the `search` gates payload by adding the `message` to the gate
 
 ```json
 {
   "data": [
     {
       "id": 1,
-      "name": "Lou West",
       "gates": {
         "authorized_to_update": {
           "allowed": false,

--- a/content/4.digging-deeper/3.gates.md
+++ b/content/4.digging-deeper/3.gates.md
@@ -38,3 +38,45 @@ class UserResource extends Resource
     // ...
 }
 ```
+
+## Policy message in gates
+
+You are able to get policies message if you want to be more explicit about why the policy is not passing, you first need to set the 
+config `rest.gates.message.enabled` to true. Be aware that this will change the gates format
+
+In your policy you need to return a policy message:
+
+```php
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+ 
+/**
+ * Determine if the given post can be updated by the user.
+ */
+public function update(User $user, Post $post): Response
+{
+    return $user->id === $post->user_id
+        ? Response::allow()
+        : Response::deny('You do not own this post.');
+}
+```
+
+and this will result in the change of the `search` gating format:
+
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "name": "Lou West",
+      "gates": {
+        "authorized_to_update": {
+          "allowed": false,
+          "message": "You do not own this post."
+        }
+      }
+    }
+  ]
+}
+```

--- a/content/4.digging-deeper/3.gates.md
+++ b/content/4.digging-deeper/3.gates.md
@@ -62,7 +62,7 @@ public function update(User $user, Post $post): Response
 }
 ```
 
-This changes the `search` gates payload by adding the `message` to the gate
+This changes the `search` gates payload by adding a `message` and `allowed` keys:
 
 ```json
 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a section on policy messages in gates.
  * Describes enabling gate messages via a configuration flag and notes the resulting format change.
  * Includes an example policy returning allow/deny with a message.
  * Shows a sample response where a denied gate includes a message field.
  * No functional or public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->