### PR TITLE
Auto-generate documentation with Scramble

### DIFF
--- a/content/4.digging-deeper/8.documentation.md
+++ b/content/4.digging-deeper/8.documentation.md
@@ -1,179 +1,176 @@
+# Documentation
+
+Laravel Rest API provides first-class integration with [Scramble](https://scramble.dedoc.co) to automatically generate your API documentation from your resources, fields, relations and validation rules — with zero manual configuration.
+
+> **The legacy `rest:documentation` command is deprecated** and will be removed in a future major version. We recommend migrating to the Scramble-based integration described below.
+
+## Scramble integration (recommended)
+
+### Installation
+
+Install Scramble in your project:
+```bash
+composer require dedoc/scramble
+```
+
+Then register the Lomkit extension in your `AppServiceProvider::boot()`:
+```php
+use Dedoc\Scramble\Scramble;
+
+Scramble::configure()
+    ->withExtensions([
+        \Lomkit\Rest\Documentation\LomkitOperationExtension::class,
+    ]);
+```
+
+That's it. Visit `/docs/api` to see your fully generated documentation.
+
 ---
-description: Documentation is a feature provided by Laravel Rest API that offers an automated way to expose your API endpoints and more.
+
+### What is auto-generated
+
+The extension reads your resources at boot time and automatically documents:
+
+- **Fields** — all fields exposed via `fields()`, with their inferred OpenAPI type
+- **Validation rules** — rules from `rules()`, `createRules()` and `updateRules()` are reflected as field descriptions and types
+- **Relations** — all relations from `relations()`, including their Lomkit type (`BelongsTo`, `HasMany`, `BelongsToMany`, etc.)
+- **Search body** — filters, sorts, selects, includes, scopes, pagination
+- **Mutate body** — `attributes` object with all fields, nested `relations` block with the correct structure (single object vs array) per relation type
+- **Destroy / Restore body** — `resources` array of IDs
+
 ---
 
-You can access comprehensive customization options to enrich the documentation, including the ability to incorporate your own custom routes, for instance.
+### Customization
 
-## Generating documentation
+The Lomkit extension is a standard Scramble extension. Every option Scramble provides — authentication schemes, servers, route filtering, custom routes, UI customization — is available to you without any restriction.
 
-Each time you need to update the documentation, you have to run the `rest:documentation` command:
+For a complete reference, refer to the [Scramble documentation](https://scramble.dedoc.co).
 
+#### Filtering routes by authentication
+
+A common pattern is to hide auth-protected routes from unauthenticated users:
+```php
+use Dedoc\Scramble\Scramble;
+use Illuminate\Routing\Route;
+use Lomkit\Rest\Http\Controllers\Controller as LomkitController;
+
+Scramble::routes(function (Route $route) {
+    $controller = $route->getController();
+
+    if (!$controller instanceof LomkitController) {
+        return false;
+    }
+
+    if (!auth()->check()) {
+        $protected = ['auth', 'auth:sanctum', 'auth:api', 'auth:passport'];
+
+        if (collect($route->gatherMiddleware())->intersect($protected)->isNotEmpty()) {
+            return false;
+        }
+    }
+
+    return true;
+});
+```
+
+---
+
+## Legacy documentation (deprecated)
+
+> ⚠️ The following approach is **deprecated** as of version X.X and will be removed in the next major release. Please migrate to the Scramble integration above.
+
+### Generating documentation
 ```bash
 php artisan rest:documentation
 ```
 
-The documentation is generated based on registered routes, if you don't expose all the routes on a certain Rest Resource, they won't appear in the documentation.
+The documentation is generated based on registered routes. It is stored in your `public` folder and should be committed to version control. Avoid running this command directly on production — generate locally during development instead.
 
-Keep in mind that the documentation will be stored in your public folder and be git committed. Avoid updating your documentation directly on production servers. Instead, update it locally during development.
-
-By default, the generated documentation will be accessible via `/api-documentation`. If you want to customize this or disable it, change your `rest.routing` documentation.
+By default the generated documentation is accessible at `/api-documentation`. To customize or disable this, update the `rest.routing` configuration.
 
 ### Configure data
 
-To achieve this, you need to be familiar with OpenApi. If you aren't, please consult the [documentation](https://spec.openapis.org/oas/v3.1.0)
-
-You can to configure OpenApi information, servers and security in your configuration file `config/rest.php`:
+You can configure OpenAPI information, servers and security in `config/rest.php`:
 ```php
-[
-    /*
-    |--------------------------------------------------------------------------
-    | Rest Documentation
-    |--------------------------------------------------------------------------
-    |
-    | This is the feature that automatically generates your API documentation for you.
-    | Laravel Rest Api will validate each searched / mutated / deleted model to avoid leaks in your API.
-    | This feature is based on OpenApi, for more details see: https://swagger.io/specification/
-    |
-    */
-
-    'documentation' => [
-        'info' => [
-            'title' => config('app.name'),
-            'summary' => 'This is my projet\'s documentation',
-            'description' => 'Find out all about my projet\'s API',
-            'termsOfService' => null, // (Optional) Url to terms of services
-            'contact' => [
-                'name' => 'My Company',
-                'email' => 'email@company.com',
-                'url' => 'https://company.com'
-            ],
-            'license' => [
-                'url' => null,
-                'name' => 'Apache 2.0',
-                'identifier' => 'Apache-2.0'
-            ],
-            'version' => '1.0.0'
+'documentation' => [
+    'info' => [
+        'title'          => config('app.name'),
+        'summary'        => 'This is my project\'s documentation',
+        'description'    => 'Find out all about my project\'s API',
+        'termsOfService' => null,
+        'contact' => [
+            'name'  => 'My Company',
+            'email' => 'email@company.com',
+            'url'   => 'https://company.com',
         ],
-        // See https://spec.openapis.org/oas/v3.1.0#server-object
-        'servers' => [
-            [
-                'url' => '/', // Relative to current
-                'description' => 'The current server'
-            ],
-//            [
-//                'url' => '"https://my-server.com:{port}/{basePath}"',
-//                'description' => 'Production server',
-//                'variables' => [
-//                    'port' => [
-//                        'enum' => ['80', '443'],
-//                        'default' => '443'
-//                    ],
-//                    'basePath' => [
-//                        'default' => 'v2',
-//                        'enum' => ['v1', 'v2'],
-//                    ]
-//                ]
-//            ]
+        'license' => [
+            'url'        => null,
+            'name'       => 'Apache 2.0',
+            'identifier' => 'Apache-2.0',
         ],
-        // See https://spec.openapis.org/oas/v3.1.0#security-scheme-object
-        'security' => [
-//            [
-//                'type' => 'http',
-//                'description' => 'description',
-//                'scheme' => 'Bearer',
-//                'bearerFormat' => 'JWT'
-//            ],
-//            [
-//                'type' => 'oauth2',
-//                'flows' => [
-//                    'authorizationCode' => [
-//                        'scopes' => ['write:pets'],
-//                        'tokenUrl' => 'https://example.com/api/oauth/token',
-//                        'authorizationUrl' => 'https://example.com/api/oauth/dialog',
-//                        'refreshUrl' => 'https://example.com/api/oauth/refresh',
-//                    ]
-//                ]
-//            ]
-        ]
-    ]
-]
+        'version' => '1.0.0',
+    ],
+    'servers'  => [
+        ['url' => '/', 'description' => 'The current server'],
+    ],
+    'security' => [],
+],
 ```
 
-### Extend the routes
+### Extend operations
 
-To achieve this, you need to be familiar with OpenApi. If you aren't, please consult the [documentation](https://spec.openapis.org/oas/v3.1.0)
-
-If, for any reason, you need to change an operation, you can extend the corresponding operation on your controller:
-
+If you need to customize a specific operation, override the corresponding method on your controller:
 ```php
 namespace App\Rest\Controllers;
 
 class UsersController
 {
-    /**
-     * Extend "detail" documentation operation
-     * @param Operation $operation
-     * @return Operation
-     */
     public function generateDocumentationDetailOperation(\Lomkit\Rest\Documentation\Schemas\Operation $operation): Operation
     {
-        return $operation
-            ->withTags(['my custom tag']);
+        return $operation->withTags(['my custom tag']);
     }
 }
 ```
 
-All the available methods are: `generateDocumentationDetailOperation`, `generateDocumentationSearchOperation`, `generateDocumentationMutateOperation`, 
-`generateDocumentationActionsOperation`, `generateDocumentationDestroyOperation`, `generateDocumentationRestoreOperation` and `generateDocumentationForceDeleteOperation`.
+Available methods: `generateDocumentationDetailOperation`, `generateDocumentationSearchOperation`, `generateDocumentationMutateOperation`, `generateDocumentationActionsOperation`, `generateDocumentationDestroyOperation`, `generateDocumentationRestoreOperation`, `generateDocumentationForceDeleteOperation`.
 
-To define the documentation, Laravel Rest API creates an object for each OpenAPI argument with all its attributes.
+### Add your own routes
 
-## Add your own routes
-
-To achieve this, you need to be familiar with OpenApi. If you don't, please consult the [documentation](https://spec.openapis.org/oas/v3.1.0)
-
-First you'll need to generate a dedicated `RestDocumentationServiceProvider` class:
+Generate a dedicated service provider:
 ```bash
 php artisan rest:documentation-provider
 ```
 
-Then add the freshly generated service provider to your providers in your `bootstrap/providers.php` file:
+Register it in `bootstrap/providers.php`:
 ```php
-    return [
-        // ...
-        App\Providers\RestDocumentationServiceProvider::class
-    ];
+return [
+    App\Providers\RestDocumentationServiceProvider::class,
+];
 ```
 
-You are then free to declare your own routes in your freshly generated service provider:
-
+Then declare custom routes in its `boot()` method:
 ```php
-    /**
-     * Bootstrap any application services.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        Rest::withDocumentationCallback(function (OpenAPI $openAPI) {
-            $openAPI->withPaths(
-                [
-                    'myPath' => (new Path)
-                        ->withDescription('my custom path')
-                        ->withGet(
-                            (new Operation)
-                                ->withTags(['Callable'])
-                                ->withSummary('You should call this !')
-                        )
-                ]
-            );
-            return $openAPI;
-        });
-    }
+use Lomkit\Rest\Facades\Rest;
+use Lomkit\Rest\Documentation\Schemas\OpenAPI;
+use Lomkit\Rest\Documentation\Schemas\Operation;
+use Lomkit\Rest\Documentation\Schemas\Path;
+
+public function boot(): void
+{
+    Rest::withDocumentationCallback(function (OpenAPI $openAPI) {
+        $openAPI->withPaths([
+            'myPath' => (new Path)
+                ->withDescription('my custom path')
+                ->withGet(
+                    (new Operation)
+                        ->withTags(['Callable'])
+                        ->withSummary('You should call this !')
+                ),
+        ]);
+
+        return $openAPI;
+    });
+}
 ```
 
-To see all the schemas available and methods please see [the git repository](https://github.com/Lomkit/laravel-rest-api/tree/master/src/Documentation/Schemas).
-
-:::note
-The OpenApi passed to the callback contains the full documentation configuration.
-:::
+For all available schemas and methods, see the [GitHub repository](https://github.com/Lomkit/laravel-rest-api/tree/master/src/Documentation/Schemas).

--- a/content/4.digging-deeper/8.documentation.md
+++ b/content/4.digging-deeper/8.documentation.md
@@ -13,14 +13,14 @@ Install Scramble in your project:
 composer require dedoc/scramble
 ```
 
-Then register the Lomkit extension in your `AppServiceProvider::boot()`:
+Then register the Lomkit extension in your `config/scramble.php`:
 ```php
-use Dedoc\Scramble\Scramble;
-
-Scramble::configure()
-    ->withExtensions([
-        \Lomkit\Rest\Documentation\LomkitOperationExtension::class,
-    ]);
+return [
+    // ...
+    'extensions' => [
+        \Lomkit\Rest\Scramble\LomkitLaravelRestApiOperationExtension::class,
+    ],
+];
 ```
 
 That's it. Visit `/docs/api` to see your fully generated documentation.
@@ -77,7 +77,7 @@ Scramble::routes(function (Route $route) {
 
 ## Legacy documentation (deprecated)
 
-> ⚠️ The following approach is **deprecated** as of version X.X and will be removed in the next major release. Please migrate to the Scramble integration above.
+> ⚠️ The following approach is **deprecated** and will be removed in the next major release. Please migrate to the Scramble integration above.
 
 ### Generating documentation
 ```bash
@@ -123,9 +123,11 @@ If you need to customize a specific operation, override the corresponding method
 ```php
 namespace App\Rest\Controllers;
 
+use Lomkit\Rest\Documentation\Schemas\Operation;
+
 class UsersController
 {
-    public function generateDocumentationDetailOperation(\Lomkit\Rest\Documentation\Schemas\Operation $operation): Operation
+    public function generateDocumentationDetailOperation(Operation $operation): Operation
     {
         return $operation->withTags(['my custom tag']);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Recommend Scramble-based workflow as the default for API docs; generated docs served at /docs/api.
  * Document what Scramble auto-generates (fields, validation, relations, request bodies) and add customization options (including route filtering by auth).
  * Mark legacy documentation flow deprecated, note generation location (public) and default path (/api-documentation).
  * Simplify OpenAPI examples, rename guidance to “Extend operations,” and refresh provider/boot examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->