### PR TITLE
Document Laravel-style field validation for actions and instructions

### DIFF
--- a/content/4.digging-deeper/1.actions.md
+++ b/content/4.digging-deeper/1.actions.md
@@ -140,7 +140,13 @@ class SendWelcomeNotificationAction extends Action
 }
 ```
 
-In the returned array, the key should correspond to the field name provided in the call, while the value should represent the desired set of validations for that field. Laravel Rest API automatically validates all fields based on your defined validation rules.
+In the returned array, the key should correspond to the field name provided in the call, while the value should represent the desired set of validations for that field. Laravel Rest API validates your fields exactly like a native Laravel validation: your rules run against the fields as if they were a `{name: value}` payload, so presence and cross-field rules — `required`, `required_if`, `present`, and the like — are enforced even when the field is missing from the request body.
+
+Validation errors are keyed by field name (`fields.{name}`, e.g. `fields.expires_at`), while sending an unknown field name is reported positionally as `fields.{index}.name`.
+
+:::warning
+This is a breaking change from earlier versions, where rules only applied to fields actually present in the request: a `required` field that was omitted did not raise an error. Omitting a required field now returns a `422`, and field-level validation errors moved from `fields.{index}.value` to `fields.{name}`.
+:::
 
 You get those fields in the `$field` variable in your `handle` method.
 

--- a/content/4.digging-deeper/6.instructions.md
+++ b/content/4.digging-deeper/6.instructions.md
@@ -140,7 +140,13 @@ class OddEvenIdInstruction extends Instruction
 }
 ```
 
-In the returned array, the key should correspond to the field name provided in the call, while the value should represent the desired set of validations for that field. Laravel Rest API automatically validates all fields based on your defined validation rules.
+In the returned array, the key should correspond to the field name provided in the call, while the value should represent the desired set of validations for that field. Laravel Rest API validates your fields exactly like a native Laravel validation: your rules run against the fields as if they were a `{name: value}` payload, so presence and cross-field rules — `required`, `required_if`, `present`, and the like — are enforced even when the field is missing from the request body.
+
+Validation errors are keyed by field name (`search.instructions.{index}.fields.{name}`), while sending an unknown field name is reported positionally as `search.instructions.{index}.fields.{index}.name`.
+
+:::warning
+This is a breaking change from earlier versions, where rules only applied to fields actually present in the request: a `required` field that was omitted did not raise an error. Omitting a required field now returns a `422`, and field-level validation errors moved from `search.instructions.{index}.fields.{index}.value` to `search.instructions.{index}.fields.{name}`.
+:::
 
 You get those fields in the `$field` variable in your `handle` method.
 


### PR DESCRIPTION
Documents the field-validation behavior change from Lomkit/laravel-rest-api#<numéro-issue-ou-PR>: presence and cross-field rules now apply, and the error-key contract (name-based content errors, positional unknown-name errors). Adds a breaking-change callout on the Actions and Instructions pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified field validation behavior, including presence and cross-field rules for omitted fields.
  * Documented validation error formats for named fields and unknown fields.
  * Added a breaking-change warning: omitted required fields now return `422`, and field-level error paths have changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->