### PR TITLE
docs: field validation, empty text search & Laravel 12 minimum

### DIFF
--- a/content/1.getting-started/1.installation.md
+++ b/content/1.getting-started/1.installation.md
@@ -12,7 +12,7 @@ Join our collaborative ecosystem where community contributions are welcome. Toge
 ## Requirements
 
 - PHP **8.2** or higher
-- Laravel **11.0** or higher
+- Laravel **12.0** or higher
 
 ## Installing Laravel Rest Api
 

--- a/content/2.endpoints/2.search.md
+++ b/content/2.endpoints/2.search.md
@@ -558,6 +558,10 @@ If you want to specify a full text search you'll need to use the text argument. 
 }
 ```
 
+:::note
+When `text` is provided but its `value` is empty or `null`, the endpoint returns an empty paginated result immediately, without querying the search engine.
+:::
+
 #### Impacts
 
 When using full text search, some restrictions happens to the query:

--- a/content/4.digging-deeper/1.actions.md
+++ b/content/4.digging-deeper/1.actions.md
@@ -144,6 +144,12 @@ In the returned array, the key should correspond to the field name provided in t
 
 You get those fields in the `$field` variable in your `handle` method.
 
+:::note
+Field rules are evaluated as a standard Laravel validation. This means presence and cross-field rules such as `required`, `required_if` and `present` fire **even when the field is absent** from the request — omitting a `required` field returns a `422` response.
+
+Validation errors are keyed by field name under `fields.{name}` (for example `fields.expires_at`), while an unauthorized field name is reported positionally as `fields.{index}.name`.
+:::
+
 ## Meta
 
 Because your actions are exposed to frontend users, they do receive certain information about them, such as `uriKey`, `name` and `fields`. However, you are also welcome to provide your own data.

--- a/content/4.digging-deeper/6.instructions.md
+++ b/content/4.digging-deeper/6.instructions.md
@@ -144,6 +144,10 @@ In the returned array, the key should correspond to the field name provided in t
 
 You get those fields in the `$field` variable in your `handle` method.
 
+:::note
+Instruction fields are validated exactly like action fields: as a standard Laravel validation, so presence and cross-field rules (`required`, `required_if`, `present`, …) fire even when the field is absent from the request. Validation errors are keyed by field name under `search.instructions.{index}.fields.{name}`.
+:::
+
 ## Meta
 
 Because your instructions are exposed to frontend users, they do receive certain information about them, such as `uriKey`, `name` and `fields`. However, you are also welcome to provide your own data.


### PR DESCRIPTION
Documents three package changes across the affected pages.

## Changes

### [#224 – Drop Laravel 11 support](https://github.com/Lomkit/laravel-rest-api/pull/224) (merged)
- `getting-started/installation`: bump the stated minimum from Laravel 11 to **Laravel 12**.

### [#221 – Enforce declared field rules on actions and instructions](https://github.com/Lomkit/laravel-rest-api/pull/221) (merged)
- `digging-deeper/actions` & `digging-deeper/instructions`: note that field rules now run as a **standard Laravel validation** — presence and cross-field rules (`required`, `required_if`, `present`, …) fire even when the field is absent (omitting a `required` field returns `422`), and validation errors are keyed by field name (`fields.{name}` / `search.instructions.{index}.fields.{name}`) rather than positionally.

### [#216 – Return empty paginator when scout text value is empty](https://github.com/Lomkit/laravel-rest-api/pull/216) (open)
- `endpoints/search`: note that a provided-but-empty/`null` `text.value` returns an empty paginated result immediately instead of erroring.

## Notes
- Only the four content files are touched; no line-ending/formatting churn.
- #216 is still open — if its behaviour changes before merge, the search note may need a revisit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)