### PR TITLE
chore(deps): update dependency nuxt to ^4.4.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@nuxtjs/sitemap": "8.2.2",
         "@resvg/resvg-js": "^2.6.2",
         "better-sqlite3": "^12.11.1",
-        "nuxt": "^4.4.7",
+        "nuxt": "^4.4.8",
         "nuxt-gtag": "^4.1.0",
         "nuxt-llms": "0.2.0",
         "nuxt-og-image": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@nuxtjs/sitemap": "8.2.2",
     "@resvg/resvg-js": "^2.6.2",
     "better-sqlite3": "^12.11.1",
-    "nuxt": "^4.4.7",
+    "nuxt": "^4.4.8",
     "nuxt-gtag": "^4.1.0",
     "nuxt-llms": "0.2.0",
     "nuxt-og-image": "^6.0.0",


### PR DESCRIPTION
Raises the declared `nuxt` range floor from `^4.4.7` to `^4.4.8`.

The resolved dependency tree is unchanged — the previous `^4.4.7` range already resolved to `4.4.8` in the lockfile — so this only bumps the stated minimum.

## Verification (Node 22, matching CI, in Docker)
- ✅ `npm run lint`
- ✅ `npm run typecheck`
- ✅ `npm run generate` (101 routes prerendered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)