### PR TITLE
docs: document the targeted() action state

### DIFF
--- a/content/2.endpoints/1.details.md
+++ b/content/2.endpoints/1.details.md
@@ -29,7 +29,8 @@ As a response, you'll receive the resource details:
         "meta": {
           "color": "#FFFFFF"
         },
-        "is_standalone": false
+        "standalone": false,
+        "targeted": false
       }
     ],
     "instructions": [

--- a/content/2.endpoints/4.actions.md
+++ b/content/2.endpoints/4.actions.md
@@ -64,6 +64,26 @@ As a response you'll receive the number of models that were impacted.
 
 ## Standalone actions
 
-A standalone actions is an action that does not require any models to run. You may know if an action is standalone in the detail endpoint with the `is_standalone` key.
+A standalone actions is an action that does not require any models to run. You may know if an action is standalone in the detail endpoint with the `standalone` key.
 
 Standalone actions works the same, you just can't specify a search operation.
+
+## Targeted actions
+
+A targeted action is an action that requires you to name the models it runs on. You may know if an action is targeted in the detail endpoint with the `targeted` key.
+
+Instead of a `search` operation, you pass a `resources` key holding the ids to act on. A search is not accepted here: you already know which models you want.
+
+```json
+// (POST) api/users/actions/deactivate-users
+{
+    "resources": [1, 5, 9],
+    "fields": [
+      { "name": "reason", "value": "spam" }
+    ]
+}
+```
+
+Omitting `resources` is a validation error rather than a silent update of every model, which is the point of the state. An unknown id is a validation error too, and an id you are not allowed to see is skipped, exactly as it would be filtered out of a search.
+
+The number of ids accepted in a single request is capped, and the response is the same `impacted` payload as any other action.

--- a/content/4.digging-deeper/1.actions.md
+++ b/content/4.digging-deeper/1.actions.md
@@ -376,10 +376,6 @@ use Lomkit\Rest\Actions\Action;
 
 class DeactivateUsersAction extends Action
 {
-    /**
-     * The maximum number of ids accepted in the resources key
-     * @var int
-     */
-    public $maxResources = 50;
+    public int $maxResources = 50;
 }
 ```

--- a/content/4.digging-deeper/1.actions.md
+++ b/content/4.digging-deeper/1.actions.md
@@ -330,3 +330,56 @@ class UserResource extends Resource
     }
 }
 ```
+
+## Targeted actions
+
+By default an action is free to run on every model: `search` is optional, and omitting it means the action impacts the whole table. That is fine for some actions and alarming for others, and no policy can oblige a caller to narrow it down.
+
+When an action must never be able to do that, register it as `targeted` by invoking the `targeted` method. The caller then has to pass a `resources` array of ids naming the models to act on, and a `search` is prohibited — the ids already say what to hit.
+
+```php
+use App\Rest\Actions\DeactivateUsersAction;
+
+class UserResource extends Resource
+{
+    /**
+     * The actions that should be linked
+     * @param RestRequest $request
+     * @return array
+     */
+    public function actions(RestRequest $request): array {
+        return [
+            DeactivateUsersAction::make()->targeted()
+        ];
+    }
+}
+```
+
+An action has exactly one of three targeting states:
+
+| State | `search` | `resources` | Models impacted |
+| --- | --- | --- | --- |
+| `standalone()` | prohibited | prohibited | none, `handle` receives an empty collection |
+| default | optional | prohibited | whatever the search resolves, **every model when it is omitted** |
+| `targeted()` | prohibited | required | exactly the ids named |
+
+`standalone` and `targeted` are mutually exclusive, and combining them throws an `InvalidActionStateException`.
+
+The ids are still filtered through the resource's `searchQuery`, so naming a model you are not allowed to see does not let you act on it — it is skipped, just as it would be excluded from a search.
+
+### Limiting how many models can be named
+
+Each id is validated with its own existence query, so the number accepted in one request is capped at `1000` by default. Lower it on an action whose blast radius should stay small.
+
+```php
+use Lomkit\Rest\Actions\Action;
+
+class DeactivateUsersAction extends Action
+{
+    /**
+     * The maximum number of ids accepted in the resources key
+     * @var int
+     */
+    public $maxResources = 50;
+}
+```


### PR DESCRIPTION
Documents the `targeted()` action state added in Lomkit/laravel-rest-api#223.

- **Endpoints › Actions** — the `resources` payload, why `search` is not accepted, and what a missing, unknown or unauthorized id does.
- **Digging deeper › Actions** — how to register a targeted action, the three targeting states side by side, and `$maxResources`.
- **Endpoints › Details** — corrects the action schema key: the payload emits `standalone`, not `is_standalone`, and now carries `targeted` alongside it.

Draft until Lomkit/laravel-rest-api#223 merges, since it documents behavior that does not exist in a release yet.

Not verified against a build — no Node available on the machine this was written on. The changes are markdown only (headings, fenced blocks, one table matching the style already used in authorizations.md), so the risk is a rendering nit at worst.