### PR TITLE
docs: document include aliases, targeted actions and perimeter grouping

### DIFF
--- a/content/2.endpoints/1.details.md
+++ b/content/2.endpoints/1.details.md
@@ -29,7 +29,8 @@ As a response, you'll receive the resource details:
         "meta": {
           "color": "#FFFFFF"
         },
-        "is_standalone": false
+        "standalone": false,
+        "targeted": false
       }
     ],
     "instructions": [

--- a/content/2.endpoints/2.search.md
+++ b/content/2.endpoints/2.search.md
@@ -43,6 +43,13 @@ Here is a quick look at what you can do:
         "limit": 2
       },
       {
+        "relation": "posts",
+        "alias": "draftPosts",
+        "filters": [
+          {"field": "published", "value": false}
+        ]
+      },
+      {
         "relation": "user",
         "filters": [
           {
@@ -100,6 +107,7 @@ Here is a quick look at what you can do:
 | `selects.field`       | `string` | X                                    |             | The name of the field                                                                                          |
 | **Includes**          |          |                                      |             |                                                                                                                |
 | `includes.relation`   | `string` | X                                    |             | The relation you are querying                                                                                  |
+| `includes.alias`      | `string` |                                      |             | The key the relation is returned under, allowing the same relation to be included multiple times               |
 | `includes.other`      | `mixed`  |                                      | `50`        | You can specify all the arguments in the current page such as `filters`, `limit`, `scopes`, etc except include |
 | **Aggregates**        |          |                                      |             |                                                                                                                |
 | `aggregates.relation` | `string` | X                                    |             | The relation you are querying                                                                                  |
@@ -377,6 +385,73 @@ This allows you to do the following:
           {"field": "id", "operator": "in", "value": [1, 3]}
         ],
         "limit": 2
+      }
+    ]
+  }
+}
+```
+
+#### Aliasing an include
+
+By default a relation is returned under its own name, which means it can only appear once in the response. Provide an `alias` to choose the key it is returned under, and the same relation can be included several times with different constraints:
+
+```json
+// (POST) api/posts/search
+{
+  "search": {
+    "includes": [
+      {
+        "relation": "comments",
+        "alias": "approvedComments",
+        "filters": [
+          {"field": "approved", "value": true}
+        ]
+      },
+      {
+        "relation": "comments",
+        "alias": "pendingComments",
+        "filters": [
+          {"field": "approved", "value": false}
+        ]
+      }
+    ]
+  }
+}
+```
+
+Each post then carries an `approvedComments` and a `pendingComments` key instead of a single `comments` key. Including a relation both natively and under an alias is allowed, and both keys are returned.
+
+The alias is used verbatim as the response key, so it is not converted to snake case the way a relation name is.
+
+:::warning
+Because the alias becomes a key of the response, it is validated:
+
+- it must look like an identifier, matching `^[A-Za-z_][A-Za-z0-9_]*$`, and be at most 255 characters
+- it must be unique across the includes of the same level
+- it may not collide with a field of the resource, one of its relations, or the [gates](/digging-deeper/gates) key
+- it is not allowed on a dotted relation path such as `posts.comments`
+
+Anything else returns a `422` response.
+:::
+
+A dotted path has no single level the alias could key into, so alias the relation through a nested `includes` entry instead:
+
+```json
+// (POST) api/users/search
+{
+  "search": {
+    "includes": [
+      {
+        "relation": "posts",
+        "includes": [
+          {
+            "relation": "comments",
+            "alias": "approvedComments",
+            "filters": [
+              {"field": "approved", "value": true}
+            ]
+          }
+        ]
       }
     ]
   }

--- a/content/2.endpoints/4.actions.md
+++ b/content/2.endpoints/4.actions.md
@@ -50,6 +50,24 @@ Specify your arguments in the `search` argument:
 }
 ```
 
+### Targeting models explicitly
+
+When you already know which models the action applies to, an action declared as [targeted](/digging-deeper/actions#targeted-actions) takes the list of ids in the `resources` argument instead of a search:
+
+```json
+// (POST) api/users/actions/deactivate-users
+{
+    "resources": [1, 5, 9],
+    "fields": [
+      { "name": "reason", "value": "spam" }
+    ]
+}
+```
+
+`resources` is required on a targeted action, and a search is prohibited on it, so the action can never impact every model because the caller forgot to narrow it down. Omitting `resources`, passing an empty array, naming an id that does not exist, or passing more ids than the action accepts all return a `422` response.
+
+Ids the current user is not allowed to see are silently skipped, since the resource's [search query](/resources/interactions#search-query) still constrains the targeted models.
+
 ## Response
 
 As a response you'll receive the number of models that were impacted.
@@ -62,8 +80,18 @@ As a response you'll receive the number of models that were impacted.
 }
 ```
 
+## Targeting states
+
+An action has exactly one of three targeting states, which decides what its request body may carry. The [details endpoint](/endpoints/details) exposes the state through the `standalone` and `targeted` keys of each action.
+
+| State | `search` | `resources` | Models impacted |
+|-------|----------|-------------|-----------------|
+| Standalone | prohibited | prohibited | none, the action receives an empty collection |
+| Classic (default) | optional | prohibited | whatever the search resolves, which is **every model** when the search is omitted |
+| Targeted | prohibited | required | exactly the ids named, minus those the user may not see |
+
 ## Standalone actions
 
-A standalone actions is an action that does not require any models to run. You may know if an action is standalone in the detail endpoint with the `is_standalone` key.
+A standalone action is an action that does not require any models to run. You may know if an action is standalone in the detail endpoint with the `standalone` key.
 
 Standalone actions works the same, you just can't specify a search operation.

--- a/content/3.resources/5.interactions.md
+++ b/content/3.resources/5.interactions.md
@@ -10,6 +10,10 @@ Here you can modify the queries before they are run by Laravel Rest Api.
 You may only want to modify the search query since all other queries use Policies to verify if the user is allowed to access/modify the data.
 :::
 
+:::note
+The constraints you add in `searchQuery`, `destroyQuery`, `restoreQuery` and `forceDeleteQuery` are applied as a nested group, so an `or` inside them cannot leak into the constraints Laravel Rest Api appends afterwards. A query written as `$query->where('user_id', $request->user()->id)->orWhere('public', true)` therefore behaves as `(user_id = ? or public = ?) and ...`, and keeps constraining when the endpoint narrows the results down further with the caller's filters or the ids it named.
+:::
+
 ### Search Query
 
 ```php[UserResource.php]

--- a/content/4.digging-deeper/1.actions.md
+++ b/content/4.digging-deeper/1.actions.md
@@ -330,3 +330,71 @@ class UserResource extends Resource
     }
 }
 ```
+
+## Targeted actions
+
+By default an action resolves the models it applies to from the search given by the caller, which means that omitting the search runs the action against **every** model of the resource. When this is not an acceptable outcome, register the action as `targeted` by invoking the `targeted` method. The caller then has to name the models by id in the `resources` argument, and providing a search is prohibited.
+
+```php
+use App\Rest\Actions\DeactivateUsersAction;
+
+class UserResource extends Resource
+{
+    /**
+     * The actions that should be linked
+     * @param RestRequest $request
+     * @return array
+     */
+    public function actions(RestRequest $request): array {
+        return [
+            DeactivateUsersAction::make()->targeted()
+        ];
+    }
+}
+```
+
+You may also declare the state on the action itself with the `targeted` property:
+
+```php
+namespace App\Rest\Actions;
+
+use Lomkit\Rest\Actions\Action;
+
+class DeactivateUsersAction extends Action
+{
+    /**
+     * Indicates if the action requires an explicit list of resource ids.
+     *
+     * @var bool
+     */
+    public $targeted = true;
+}
+```
+
+The targeted models still go through the resource's [search query](/resources/interactions#search-query), so an id the current user is not allowed to see is skipped rather than acted on.
+
+Each id is validated with its own existence query, so the number of ids a single request may carry is capped at `1000`. Declare the `maxResources` property to lower it on an action whose blast radius should stay small:
+
+```php
+namespace App\Rest\Actions;
+
+use Lomkit\Rest\Actions\Action;
+
+class DeactivateUsersAction extends Action
+{
+    public $targeted = true;
+
+    /**
+     * The maximum number of ids the action accepts per request.
+     */
+    public int $maxResources = 50;
+}
+```
+
+:::warning
+`maxResources` is typed on the parent class, so an override must repeat the `int` type. Declaring `public $maxResources = 50;` without it is a PHP fatal error.
+:::
+
+:::note
+An action cannot be both standalone and targeted, the two states are mutually exclusive. Combining them throws an `InvalidActionStateException`.
+:::


### PR DESCRIPTION
Documents the three latest merges into [`lomkit/laravel-rest-api`](https://github.com/Lomkit/laravel-rest-api).

| PR | Change |
|---|---|
| [#227](https://github.com/Lomkit/laravel-rest-api/pull/227) | Allow aliasing includes to load a relation |
| [#223](https://github.com/Lomkit/laravel-rest-api/pull/223) | Add a `targeted()` action state requiring an explicit resources target |
| [#229](https://github.com/Lomkit/laravel-rest-api/pull/229) | Group the perimeter on destroy, restore and forceDelete |

## Include aliases

`content/2.endpoints/2.search.md` — adds `alias` to the search payload example and to the specifications table, plus an "Aliasing an include" subsection covering:

- the same relation included several times under different constraints
- the alias being used verbatim as the response key, so it is not snake-cased the way a relation name is
- including a relation both natively and under an alias, which returns both keys
- the validation applied to the alias: identifier shape, `max:255`, uniqueness among sibling includes, and the collisions rejected (a field, a relation, the gates key)
- the nested `includes` form to use instead on a dotted relation path, where an alias has no single level to key into

## Targeted actions

`content/2.endpoints/4.actions.md` — a "Targeting models explicitly" section for the `resources` argument and the cases that return a `422`, plus a "Targeting states" table for the three now-disjoint states and what each accepts.

`content/4.digging-deeper/1.actions.md` — a "Targeted actions" section covering `targeted()`, the `$targeted` property, why the state exists (a classic action with no search runs against every model), the perimeter still applying to the targeted ids, `$maxResources` and the `int` type an override has to repeat, and the `InvalidActionStateException` thrown when standalone and targeted are combined.

## Perimeter grouping

`content/3.resources/5.interactions.md` — a note that the constraints declared in `searchQuery`, `destroyQuery`, `restoreQuery` and `forceDeleteQuery` are applied as a nested group, so an `or` inside them keeps constraining once the endpoint narrows the results down further. `mutateQuery` is deliberately left out of the list — it is applied through `tap` and is not grouped.

## Drive-by fix

The details endpoint payload in `content/2.endpoints/1.details.md` advertised an `is_standalone` key the API has never returned. `Action::jsonSerialize()` returns `standalone`, and as of #223 also `targeted`. Both are now shown, and the prose in `4.actions.md` that referred to `is_standalone` is corrected.

## Verification

- every JSON block in the touched files parses (29 blocks)
- the added PHP snippets pass `php -l`
- every internal link target and anchor used resolves to an existing page/heading

The Nuxt build was not run — no Node available in the environment this was written in.

## Known issue left alone

`content/2.endpoints/2.search.md` still states that an include accepts every search argument "except `include`". Nested `includes` are in fact validated (`Search` recurses through `SearchInclude`) and covered by tests (`SearchIncludingRelationshipsOperationsTest.php:317`), and the new alias section relies on them. Fixing that line is unrelated to these three merges so it is not touched here; the same stale claim also ships in the Boost `SKILL.md`.
